### PR TITLE
Fixes curl

### DIFF
--- a/_cartodb-platform/import-api.md
+++ b/_cartodb-platform/import-api.md
@@ -31,7 +31,7 @@ Suppose we have a CartoDB account whose username is *documentation* and we want 
 
 <div class="code-title code-request">REQUEST</div>
 {% highlight bash %}
-curl -F file=@/home/documentation/Documents/prism_tour.csv 
+curl -v -d -F file=@/home/documentation/Documents/prism_tour.csv 
 "https://documentation.cartodb.com/api/v1/imports/?api_key=3102343c42da0f1ffe6014594acea8b1c4e7fd64"
 {% endhighlight %}
 


### PR DESCRIPTION
From SB/4931548 we noticed (@kartones) that the previous call wasn't working.


-d, --data <data>

(HTTP) Sends the specified data in a POST request to the HTTP server, in

kartones [12:36 PM]
-F, --form <name=content>

(HTTP) This lets curl emulate a filled-in form in which a user has pressed the submit button. This causes curl to POST data using the Content-Type multipart/form-data according to RFC 2388. This enables uploading of binary files etc. To force the 'content' part to be a file, prefix the file name with an @ sign.