### PR TITLE
Adds left margin to .content ul and .content ol

### DIFF
--- a/_scss/main.scss
+++ b/_scss/main.scss
@@ -775,9 +775,10 @@
 /* =Platform
 ----------------------------------------------- */
 
-.platform-list {
+ul.platform-list {
   @extend %clearfix;
   margin-bottom: 24px;
+  margin-left: 0px;
 
   li {
     margin: 0;
@@ -817,7 +818,9 @@
 /* =Tutorials
 ----------------------------------------------- */
 
-.tutorials-list {
+ul.tutorials-list {
+  margin-left: 0px;
+
   li {
     margin: 0;
     padding: 0;

--- a/_scss/main.scss
+++ b/_scss/main.scss
@@ -436,6 +436,8 @@
 
   ul,
   ol {
+    margin-left: 30px;
+
     ul,
     ol {
       margin-top: 12px;


### PR DESCRIPTION
Not sure if this was done on purpose or not, but I personally find it a bit unaligned: 

![captura de pantalla 2015-05-18 a las 15 33 32](https://cloud.githubusercontent.com/assets/390398/7681828/a17d4116-fd73-11e4-9733-b8465ede9f5e.png)

This PR adds some left margin so that it looks like this:

![captura de pantalla 2015-05-18 a las 15 33 41](https://cloud.githubusercontent.com/assets/390398/7681879/06016734-fd74-11e4-8aa9-dad0881764e4.png)

@matallo, what do you think?