### PR TITLE
corrected 'ArcGIS Online' >> 'ArcGIS Server'

### DIFF
--- a/_cartodb-platform/import-api.md
+++ b/_cartodb-platform/import-api.md
@@ -17,8 +17,8 @@ The CartoDB Import API allows you to upload files to a CartoDB account, check on
 
 Additionally, CartoDB offers a set of connectors to import specific types of datasets:
 
-- **ArcGIS**  
-  Allows to import ArcGIS layers into a CartoDB account as tables from an ArcGIS server (version 10.1 or higher is required). Note that **this connector is disabled by default** in the CartoDB importer options. If you are interested in enabling it, please contact [support@cartodb.com](mailto:support@cartodb.com) to gain further details.
+- **ArcGIS Server**  
+  Allows to import ArcGIS layers into a CartoDB account as tables from ArcGIS Server (version 10.1 or higher is required). Note that **this connector is disabled by default** in the CartoDB importer options. If you are interested in enabling it, please contact [support@cartodb.com](mailto:support@cartodb.com) to gain further details.
 
 
 ## Quickstart
@@ -686,7 +686,7 @@ curl -v --request "PUT" "https://{account}.cartodb.com/api/v1/synchronizations/<
 
 ### Import an ArcGIS layer
 
-ArcGIS layers stored in an ArcGIS server can get imported as CartoDB tables. Such layers must be accessible via an **ArcGIS API REST URL** whose structure is as follows:
+ArcGIS layers stored in ArcGIS Server can get imported as CartoDB tables. Such layers must be accessible via an **ArcGIS API REST URL** whose structure is as follows:
 {% highlight html %}
 http://<host>/<site>/rest/services/<folder>/<serviceName>/<serviceType>/<layer_ID>
 {% endhighlight %}

--- a/cartodb-editor.md
+++ b/cartodb-editor.md
@@ -55,9 +55,9 @@ To use Twitter data in a map, select the Twitter icon in the upload window. Next
 
 **You also have the option to import from:**
 
-1. **ArcGIS online**
+1. **ArcGIS Server (10.1 or higher)**
 2. **Salesforce**
-3. **Mailchimp**
+3. **MailChimp**
 
 <p class="wrap-border"><img src="{{ '/img/layout/cartodb-editor/connectdataset2.png' | prepend: site.baseurl }}" alt="Adding datasets from other sources" /></p>
 


### PR DESCRIPTION
@iriberri - hey there - changed ‘ArcGIS Online’ to ‘ArcGIS Server’ in our docs…since that’s where we support import from.

please review and pull?