### PR TITLE
updated footer.html file with Andrews syntax changes for correct redi…

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -54,7 +54,7 @@
         <li class="Footer-column">
           <dl>
             <dt class="Footer-title">Learn</dt>
-            <dd><a class="Footer-link" href="{{ site.cartodb-baseurl }}/docs/">Documentation</a></dd>
+            <dd><a class="Footer-link" href="{{ site.url }}">Documentation</a></dd>
             <dd><a class="Footer-link" href="{{ site.cartodb-baseurl }}/webinars/">Webinars</a></dd>
             <dd><a class="Footer-link" href="/tutorials.html">Tutorials</a></dd>
             <dd><a class="Footer-link" href="{{ site.academy-baseurl }}">The Map Academy</a></dd>


### PR DESCRIPTION
…rect
@andrewxhill I have applied this syntax to the footer.html.  This change can be merged if you approve.
- This only fixes the footer link from the Docs repo though, it does not change the fact that this "other" site exist.
- The CartoDB website will have to apply these changes to their footers as well- their footers currently point to the "other" page (https://cartodb.com/docs).  However, the CartoDB website / Resources / Documentation link correctly points to the actual documentation... so there is some inconsistency there.  Perhaps they want to rename the other page to "Learn" so it's not confused with Documentation. Who should I speak to about website repo consistency for documentation links?